### PR TITLE
fix: remove unuse field in alert_manager.Service

### DIFF
--- a/src/controllers/add-ons/autocomplete/config.json
+++ b/src/controllers/add-ons/autocomplete/config.json
@@ -2,8 +2,8 @@
     "resourceTypes": {
         "alert_manager.Service":{
             "request": {
-                "search": ["service_id", "name", "title"],
-                "only": ["service_id", "name", "title"]
+                "search": ["service_id", "name"],
+                "only": ["service_id", "name"]
             },
             "response": {
                 "key": "service_id",


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Remove unuse field in alert_manager.Service